### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   open_router!


### PR DESCRIPTION
Updated Gemfile.lock for linux

`bundle lock --add-platform x86_64-linux`